### PR TITLE
Fix Phaser import usage

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,4 +1,4 @@
-import { Game } from 'phaser';
+import Phaser from 'phaser';
 import { gameConfig } from './config/gameConfig';
 import { Boot } from '../game/scenes/Boot';
 import { GameOver } from '../game/scenes/GameOver';
@@ -25,8 +25,8 @@ const scenes = [
 ];
 
 const StartGame = (parent: string) => {
-    return new Game({ 
-        ...gameConfig, 
+    return new Phaser.Game({
+        ...gameConfig,
         parent,
         scene: scenes
     });


### PR DESCRIPTION
## Summary
- fix Phaser import to use default export

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'phaser' ...)*

------
https://chatgpt.com/codex/tasks/task_b_68515965e95c83309153031dfc89defb